### PR TITLE
Update bullseye submodule and cloning to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "cmake"]
 	path = cmake
-	url = git://github.com/dlech/vala-cmake-modules
+	url = https://github.com/dlech/vala-cmake-modules
 [submodule "doc/sphinx/_html_extra"]
 	path = doc/sphinx/_html_extra
 	url = https://github.com/ev3dev/ev3devKit.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ LIBRARY
 PACKAGES
     ${COMMON_PACKAGES}
 CUSTOM_VAPIS
-    bindings/*.vapi
+    "${CMAKE_CURRENT_SOURCE_DIR}/bindings/*.vapi"
 OPTIONS
     --target-glib=${TARGET_GLIB}
     ${GRX3_VAPIDIR_OPTION}
@@ -236,8 +236,8 @@ if (EV3DEVKIT_BUILD_DEMO)
         ${DEVICES_DEMO_SOURCE_FILES}
     PACKAGES
         ${EXEC_PACKAGES}
-    CUSTOM_VAPIS
-        bindings/*.vapi
+    CUSTOM_VAPIS 
+        "${CMAKE_CURRENT_SOURCE_DIR}/bindings/*.vapi"
     OPTIONS
         --target-glib=${TARGET_GLIB}
         --vapidir=${CMAKE_CURRENT_BINARY_DIR}
@@ -271,7 +271,7 @@ if (EV3DEVKIT_BUILD_DEMO)
     PACKAGES
         ${EXEC_PACKAGES}
     CUSTOM_VAPIS
-        bindings/*.vapi
+        "${CMAKE_CURRENT_SOURCE_DIR}/bindings/*.vapi"
     OPTIONS
         --target-glib=${TARGET_GLIB}
         --vapidir=${CMAKE_CURRENT_BINARY_DIR}
@@ -306,7 +306,7 @@ if (VALADOC_FOUND)
     include (ValadocGenerate)
     generate_valadoc (
         ${LIBRARY_SOURCE_FILES}
-        bindings/*.vapi
+        "${CMAKE_CURRENT_SOURCE_DIR}/bindings/*.vapi"
     PACKAGE_NAME
         ${PROJECT_NAME}
     PACKAGE_VERSION

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is currently in the development stages and is unstable.
 
 This project uses git and git submodules.
 
-    git clone --recursive git://github.com/ev3dev/ev3devKit
+    git clone --recursive https://github.com/ev3dev/ev3devKit
 
 
 ## Cross-compiling for the EV3

--- a/src/ui/Screen.vala
+++ b/src/ui/Screen.vala
@@ -174,8 +174,8 @@ namespace Ev3devKit.Ui {
             if (context_mem_addr == null)
                 context = Context.new_full (mode, width, height);
             else {
-                uint8* addr[4];
-                addr[0] = context_mem_addr;
+                uint8 addr[4];
+                addr[0] = *context_mem_addr;
                 context = Context.new_full (mode, width, height, addr);
             }
         }


### PR DESCRIPTION
Notes:
* This is because GitLab has removed support for the insecure 'git://' protocol